### PR TITLE
feat: bump wrapper version to 3.0.1

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -862,7 +862,7 @@ const makeString = require('makeString');
 const makeTableMap = require('makeTableMap');
 
 // Constants
-const WRAPPER_VERSION = '3.0.0';
+const WRAPPER_VERSION = '3.0.1';
 const JS_URL = 'https://cdn.jsdelivr.net/npm/@amplitude/amplitude-js-gtm@' + WRAPPER_VERSION + '/dist/index.js';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -862,7 +862,7 @@ const makeString = require('makeString');
 const makeTableMap = require('makeTableMap');
 
 // Constants
-const WRAPPER_VERSION = '3.0.0-beta.4';
+const WRAPPER_VERSION = '3.0.0';
 const JS_URL = 'https://cdn.jsdelivr.net/npm/@amplitude/amplitude-js-gtm@' + WRAPPER_VERSION + '/dist/index.js';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
## Notes
- feat: bump wrapper version to 3.0.1

https://www.npmjs.com/package/@amplitude/amplitude-js-gtm?activeTab=versions

## Issue
While this PR bumps up the version to the latest v3.x, [with this change shipped](https://github.com/amplitude/amplitude-js-gtm/pull/10) in [amplitude-js-gtm](https://github.com/amplitude/amplitude-js-gtm).