### PR TITLE
Fix/groups

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.amplitude.com/"
 documentation: "https://www.docs.developers.amplitude.com/data/sdks/marketing-analytics-browser/"
 versions:
+  - sha: f99bc8ce73f9c346ef02dd9db1dcd984a809610f
+    changeNotes: Fix tracking events with groups.
   - sha: 61984dd2fc5735217cbef817603dcb81056077b1
     changeNotes: Set init as the default tag type.
   - sha: b17f8c1f17a8fd1278379745bffc408eb452d90c

--- a/template.tpl
+++ b/template.tpl
@@ -978,18 +978,23 @@ const onsuccess = () => {
       const eventProperties = makeTableMap(data.eventProperties || [], 'name', 'value');
 
       // Convert comma-separated groupName into an array of groupNames
-      const eventOptions = makeTableMap((data.trackEventGroups || []).map(group => {
+      const groups = makeTableMap((data.trackEventGroups || []).map(group => {
         return {
           eventGroupType: group.eventGroupType,
           eventGroupName: group.eventGroupName && group.eventGroupName.indexOf(',') > -1 ? stringToArrayAndTrim(group.eventGroupName) : group.eventGroupName
         };
       }), 'eventGroupType', 'eventGroupName') || {};
       
+      const eventOptions = {};
+      
       if (data.trackTimestamp) {
         eventOptions.time = normalize(data.trackTimestamp);
       }
       
-      _amplitude(instanceName, 'track', data.eventType, eventProperties, eventOptions);
+      _amplitude(instanceName, 'track', {
+        event_type: data.eventType, 
+        groups: groups
+      }, eventProperties, eventOptions);
       break;
       
     case 'identify':


### PR DESCRIPTION
Previously, the "track" command when tracking with groups simply included the group key-value pairs in the eventOptions object, so it looked like:

`amplitude('track', event_name, event_properties, event_options_including_groups)`

I fixed this so that groups are included in an object with event_name:

`amplitude('track', {event_type: event_name, groups: groups}, event_properties, event_options)`

Seems to work fine, but would be good to have some one take a check before merging with `main`.