### PR TITLE
feat: bumpup the wrapper version

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.amplitude.com/"
 documentation: "https://www.docs.developers.amplitude.com/data/sdks/marketing-analytics-browser/"
 versions:
+  - sha: bde379e355ff28b55bf8ae59e778873e9f8b3386
+    changeNodes: persist last event id
   - sha: aa8e9c16b2903e7c005d0d65b9c72326930a7a16
     changeNotes: Enable set revenue in revenue event.
   - sha: b2742b2da3f6d444aada18b657cb74f791e36902

--- a/template.tpl
+++ b/template.tpl
@@ -885,7 +885,7 @@ const makeString = require('makeString');
 const makeTableMap = require('makeTableMap');
 
 // Constants
-const WRAPPER_VERSION = '3.2.0';
+const WRAPPER_VERSION = '3.3.0';
 const JS_URL = 'https://cdn.jsdelivr.net/npm/@amplitude/amplitude-js-gtm@' + WRAPPER_VERSION + '/dist/index.js';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
Bump up the gtm template wrapper to persist the event id.
https://cdn.jsdelivr.net/npm/@amplitude/amplitude-js-gtm@3.3.0