### PR TITLE
fix: fix the type for identify related value

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.amplitude.com/"
 documentation: "https://www.docs.developers.amplitude.com/data/sdks/marketing-analytics-browser/"
 versions:
+  - sha: 2c09684e5a84032505891263f5dde6e52ac1418d
+    changeNodes: Fix identify/groupIdentify value field type
   - sha: bde379e355ff28b55bf8ae59e778873e9f8b3386
     changeNodes: persist last event id
   - sha: aa8e9c16b2903e7c005d0d65b9c72326930a7a16

--- a/template.tpl
+++ b/template.tpl
@@ -527,7 +527,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "TEXT"
       },
       {
-        "displayName": "Add individual user property operations each as its own row in the table. You can add as many as you like, but note that you can only include a specific User Property in a single operation. The operations are executed in order. \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/#user-properties\"\u003eMore information\u003c/a\u003e.\u003cbr/\u003e\u003cbr/\u003e",
+        "displayName": "Add individual user property operations each as its own row in the table. You can add as many as you like, but note that you can only include a specific User Property in a single operation. The operations are executed in order. \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/#user-properties\"\u003eMore information\u003c/a\u003e.\u003cbr/\u003e Please note that a hardcoded value in the `Value` field will always convert an input into a string. If you want to use other types, please create a GTM variable, specifically a Data Layer Variable. This will accurately capture the types you've specified.\u003cbr/\u003e\u003cbr/\u003e",
         "name": "identifyLabel",
         "type": "LABEL"
       },
@@ -885,7 +885,7 @@ const makeString = require('makeString');
 const makeTableMap = require('makeTableMap');
 
 // Constants
-const WRAPPER_VERSION = '3.3.0';
+const WRAPPER_VERSION = '3.4.0';
 const JS_URL = 'https://cdn.jsdelivr.net/npm/@amplitude/amplitude-js-gtm@' + WRAPPER_VERSION + '/dist/index.js';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';
@@ -1015,7 +1015,7 @@ const onsuccess = () => {
     case 'identify':
       const userProps = data.userPropertyOperations || [];
       _amplitude(instanceName, 'identify', userProps.map(op => {
-        return [op.command, op.userProperty, normalize(op.value)];
+        return [op.command, op.userProperty, op.value];
       }));
       break;
       
@@ -1027,7 +1027,7 @@ const onsuccess = () => {
     case 'groupIdentify':
       const groupUserProps = data.userPropertyOperations || [];
       _amplitude(instanceName, 'groupIdentify', data.identifyGroupType, data.identifyGroupName, groupUserProps.map(op => {
-        return [op.command, op.userProperty, normalize(op.value)];
+        return [op.command, op.userProperty, op.value];
       }));
       break;
 


### PR DESCRIPTION
Following our discussion, we prefer to remove the `normalize` function, unless there's a specific requirement for the type. We will suggest users use a variable (data layer variable) in the documentation center if they need a specific type.

We are still keeping for fields that expect a certain type, like configurations, and timestamps, and the calls are not covered in the `switch/case` statement. 