### PR TITLE
fix: default event tracking metadata

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.amplitude.com/"
 documentation: "https://www.docs.developers.amplitude.com/data/sdks/marketing-analytics-browser/"
 versions:
+  - sha: a8c3fe822f4557a44dc89a6eedb8bbeb4ebdb3a4
+    changeNodes: Fix default event tracking options
   - sha: d53219f99954bf9bf196ff751c9b5441cd3def6f
     changenotes: Fix setUserId in snippet proxy.
   - sha: 9e71a8204d409e7072de282aab08272a5be14528


### PR DESCRIPTION
Apply change of https://github.com/amplitude/amplitude-browser-sdk-gtm-template/pull/23
Copy sha from https://github.com/amplitude/amplitude-browser-sdk-gtm-template/commit/a8c3fe822f4557a44dc89a6eedb8bbeb4ebdb3a4