### PR TITLE
fix: configuration option

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1050,7 +1050,7 @@ ___TEMPLATE_PARAMETERS___
         "simpleTableColumns": [
           {
             "defaultValue": "",
-            "displayName": "Configuration.trackingOptions name",
+            "displayName": "TrackingOptions name",
             "name": "key",
             "type": "SELECT",
             "selectItems": [
@@ -1070,12 +1070,12 @@ ___TEMPLATE_PARAMETERS___
           },
           {
             "defaultValue": "",
-            "displayName": "Configuration.trackingOptions value",
+            "displayName": "TrackingOptions value",
             "name": "value",
             "type": "TEXT"
           }
         ],
-        "newRowButtonText": "Add configuration.trackingOptions",
+        "newRowButtonText": "Add trackingOption",
         "enablingConditions": [
           {
             "paramName": "initOptions",
@@ -1092,7 +1092,7 @@ ___TEMPLATE_PARAMETERS___
         "simpleTableColumns": [
           {
             "defaultValue": "",
-            "displayName": "Configuration.cookieOptions name",
+            "displayName": "CookieOptions name",
             "name": "key",
             "type": "SELECT",
             "selectItems": [
@@ -1120,12 +1120,12 @@ ___TEMPLATE_PARAMETERS___
           },
           {
             "defaultValue": "",
-            "displayName": "Configuration.cookieOptions value",
+            "displayName": "CookieOptions value",
             "name": "value",
             "type": "TEXT"
           }
         ],
-        "newRowButtonText": "Add configuration.cookieOptions",
+        "newRowButtonText": "Add cookieOption",
         "enablingConditions": [
           {
             "paramName": "initOptions",


### PR DESCRIPTION
## Description
Fix trackingOptions and cookieOptions cannot be set in GTM template
https://amplitude.atlassian.net/browse/AMP-95226
https://amplitude.atlassian.net/browse/AMP-94578

## UI change
Add two tables each for adding trackingOptions and cookieOptions under the "Configuration" table. 

GTM template has very limited UI components provided. I tried to strike a balance of keeping UI concise and requiring minimum user operations. There is another solution https://github.com/amplitude/amplitude-browser-sdk-gtm-template/issues/31 provided by our customer. But I'd like to not let customers input a Json string which is common error source. Open to discussion but I'd push harder to change my existing design unless it's huge improvement considering this PR is fixing a P1 bug. 

<img width="448" alt="Screenshot 2024-03-20 at 09 01 07" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/31029607/bf1848e7-a905-4248-b659-fb2532bc1c6d">

## Test
I tried to have unit tests for the template but unfortunately, GTM template has limited ability of testing. See more at [here](https://amplitude.atlassian.net/browse/AMP-95226?focusedCommentId=245211).

I had a local test:
- Set cookieOptions and trackingOptions at the init tag using the updated template with log level 4 (debug)
- Log the return value of `generateConfiguration()`
- Verify that it sets `amplitude.configuration` 
<img width="714" alt="Screenshot 2024-03-20 at 14 14 19" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/31029607/0b86c131-a354-4ffe-abe3-1141e5901827">
<img width="702" alt="Screenshot 2024-03-20 at 14 13 41" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/31029607/ea8eeeba-9563-4b4c-bcaf-1c642e8fe36e">

