### PR TITLE
Add update-metadata.yml

### DIFF
--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - metadata.yaml  # The workflow should only trigger on changes to metadata.yaml
+      - template.tpl  # The workflow should only trigger on changes to template.tpl
 
 jobs:
   update-metadata:

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - metadata.yaml  # The workflow should only trigger on changes to metadata.yaml
 
 jobs:
   update-metadata:

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -1,0 +1,31 @@
+name: Update Metadata
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+        # Qutoes in message are not allowed
+      - name: Update metadata.yaml
+        run: |
+          SHA=$(git rev-parse HEAD)
+          MESSAGE=$(git log -1 --pretty=%B)
+          NEW_VERSION="  - sha: $SHA\n    changeNotes: $MESSAGE"
+          echo "New version info to be added: \n"
+          echo "$NEW_VERSION"
+          sed -i "s/versions:/versions:\n$NEW_VERSION/" metadata.yaml       
+
+      - name: Commit and push if changed
+        run: |
+          git config --local user.email amplitude-sdk-bot@users.noreply.github.com
+          git config --local user.name amplitude-sdk-bot
+          git add metadata.yaml
+          git commit -m "Update metadata.yaml" || exit 0  # Exit 0 if no changes
+          git push


### PR DESCRIPTION
Add a CI file to auto commit the change of metadata needed when there is a new commit with `template.tpl` changes pushed to main to reduce the manual work to update the GTM template. 

GTM detects `metadata.yml` changes and update the template in the gallery. 

- sha: the SHA of HEAD
- changeNotes: the commit message of HEAD

I've tested it in my repo. Here is the [commit](https://github.com/Mercy811/gtm-auto-version-bump/commit/1dfe6c11f5a3ebe7ef0be41283d603994bceb6e8) the Github Action will make. 
Note that quotes in message are not supported and it causes an error like [this.](https://github.com/Mercy811/gtm-auto-version-bump/actions/runs/8383131973/job/22958243967) 
<img width="937" alt="image" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/31029607/c31840b6-576f-4751-af59-ed138f6bfc3e">
