### PR TITLE
feat: event properties object

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -428,7 +428,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid event properties object. This will overwrite the event properties in <strong>Event Properties Basic</strong> if there has any duplicate key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
+        "help": "Select a GTM variable that returns a valid event properties object. This overwrites the event properties in \u003cstrong\u003eEvent Properties Basic\u003c/strong\u003e if there has any duplicate keys. Amplitude ignores any inputs not in the object format and any value under user_properties key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
         "notSetText": "Don\u0027t set an Event Property Object"
       },
       {
@@ -1418,8 +1418,15 @@ const onsuccess = () => {
       break;
 
     case 'track':
-      const eventPropertiesBaisc = makeTableMap(data.eventPropertiesBasic || [], 'name', 'value');
-      const eventProperties = data.eventPropertiesObject && isValidObject(data.eventPropertiesObject) ? mergeObject(eventPropertiesBaisc, data.eventPropertiesObject) : eventPropertiesBaisc;
+      const propertiesBaisc = makeTableMap(data.eventPropertiesBasic || [], 'name', 'value');
+      const isValidPropertiesObject = data.eventPropertiesObject && isValidObject(data.eventPropertiesObject);
+      let eventProperties = propertiesBaisc;
+      if (isValidPropertiesObject) {
+        const cleanedPropertiesObject = JSON.parse(JSON.stringify(data.eventPropertiesObject));
+        // remove the user_properties
+        Object.delete(cleanedPropertiesObject, 'user_properties');
+        eventProperties = mergeObject(propertiesBaisc, cleanedPropertiesObject);
+      }
       
       // Convert comma-separated groupName into an array of groupNames
       const groups = makeTableMap((data.trackEventGroups || []).map(group => {

--- a/template.tpl
+++ b/template.tpl
@@ -1268,7 +1268,9 @@ const mergeObject = (baseObject, overwriteObject) => {
 
 const isValidObject = (input) => {
   const isObject = getType(input) == 'object';
-  log(LOG_PREFIX + 'Error: Invalid object input.');
+  if (!isObject) {
+    log(LOG_PREFIX + 'Error: Invalid object input.');
+  }
   return isObject;
 };
 

--- a/template.tpl
+++ b/template.tpl
@@ -1267,7 +1267,7 @@ const mergeObject = (basedObject, overwriteObject) => {
 
 const isValidObject = (input) => {
   const isObject = getType(input) == 'object';
-  log(LOG_PREFIX + 'Error: In valid object input.');
+  log(LOG_PREFIX + 'Error: Invalid object input.');
   return isObject;
 };
 

--- a/template.tpl
+++ b/template.tpl
@@ -1246,9 +1246,13 @@ const fail = msg => {
 
 // Merge two Objects
 const mergeObject = (baseObject, overwriteObject) => {
-  if (!isValidObject(baseObject) || !isValidObject(overwriteObject)) return {};
-  if (!baseObject || Object.keys(baseObject).length == 0) return overwriteObject;
-  if (!overwriteObject || Object.keys(overwriteObject).length == 0) return baseObject;
+  if (!baseObject || !isValidObject(baseObject) || Object.keys(baseObject).length == 0) {
+    return  isValidObject(overwriteObject) ? overwriteObject : {};
+  }
+
+  if (!overwriteObject ||  !isValidObject(overwriteObject) || Object.keys(overwriteObject).length == 0) {
+    return baseObject;
+  }
 
   // Clone
   const newObject = JSON.parse(JSON.stringify(baseObject));

--- a/template.tpl
+++ b/template.tpl
@@ -428,7 +428,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid event properties object. This will overwrite the event properties in <strong>Event Properties Basic</strong> if there has any duplicate key. \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
+        "help": "Select a GTM variable that returns a valid event properties object. This will overwrite the event properties in <strong>Event Properties Basic</strong> if there has any duplicate key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
         "notSetText": "Don\u0027t set an Event Property Object"
       },
       {

--- a/template.tpl
+++ b/template.tpl
@@ -428,7 +428,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid event properties object. This will overwrite the previous event properties if there has any duplicate key. \u003ca href\u003d\"\"\u003e Click here for an example\u003c/a\u003e.",
+        "help": "Select a GTM variable that returns a valid event properties object. This will overwrite the event properties in <strong>Event Properties Basic</strong> if there has any duplicate key. \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
         "notSetText": "Don\u0027t set an Event Property Object"
       },
       {

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,12 @@
-﻿___INFO___
+﻿___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
+
+___INFO___
 
 {
   "type": "TAG",
@@ -1605,3 +1613,4 @@ setup: ''
 ___NOTES___
 
 Created on 27/10/2021, 18:34:01
+

--- a/template.tpl
+++ b/template.tpl
@@ -428,7 +428,8 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Please provide object format GTM variables. This will overwrite the previous event properties if there has any duplicate key."
+        "help": "Select a GTM variable that returns a valid event properties object. This will overwrite the previous event properties if there has any duplicate key. \u003ca href\u003d\"\"\u003e Click here for an example\u003c/a\u003e.",
+        "notSetText": "Don\u0027t set an Event Property Object"
       },
       {
         "help": "Add a custom timestamp in UNIX time (milliseconds). Leave empty to use current time.",
@@ -1418,7 +1419,7 @@ const onsuccess = () => {
 
     case 'track':
       const eventPropertiesBaisc = makeTableMap(data.eventPropertiesBasic || [], 'name', 'value');
-      const eventProperties = isValidObject(data.eventPropertiesObject) ? mergeObject(eventPropertiesBaisc, data.eventPropertiesObject) : eventPropertiesBaisc;
+      const eventProperties = data.eventPropertiesObject && isValidObject(data.eventPropertiesObject) ? mergeObject(eventPropertiesBaisc, data.eventPropertiesObject) : eventPropertiesBaisc;
       
       // Convert comma-separated groupName into an array of groupNames
       const groups = makeTableMap((data.trackEventGroups || []).map(group => {

--- a/template.tpl
+++ b/template.tpl
@@ -428,7 +428,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid event properties object. This overwrites the event properties in \u003cstrong\u003eEvent Properties Basic\u003c/strong\u003e if there has any duplicate keys. Amplitude ignores any inputs not in the object format and any value under user_properties key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
+        "help": "Select a GTM variable that returns a valid event properties object. This overwrites the event properties in \u003cstrong\u003eEvent Properties Basic\u003c/strong\u003e if there are any duplicate keys. Amplitude ignores any inputs not in the object format and any value under user_properties key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
         "notSetText": "Don\u0027t set an Event Property Object"
       },
       {
@@ -1245,17 +1245,13 @@ const fail = msg => {
 };
 
 // Merge two Objects
-const mergeObject = (basedObject, overwriteObject) => {
-  if (!basedObject || Object.keys(basedObject).length == 0) return overwriteObject;
-  if (!basedObject || Object.keys(overwriteObject).length == 0) return basedObject;
+const mergeObject = (baseObject, overwriteObject) => {
+  if (!isValidObject(baseObject) || !isValidObject(overwriteObject)) return {};
+  if (!baseObject || Object.keys(baseObject).length == 0) return overwriteObject;
+  if (!overwriteObject || Object.keys(overwriteObject).length == 0) return baseObject;
 
   // Clone
-  const newObject = JSON.parse(JSON.stringify(basedObject));
-
-  if (newObject == undefined) {
-    log(LOG_PREFIX + 'Error: Input has been dropped because it\'s an unexpected Object type.');
-    return overwriteObject;
-  }
+  const newObject = JSON.parse(JSON.stringify(baseObject));
 
   Object.entries(overwriteObject).forEach((entry) => {
     const key = entry[0];
@@ -1422,6 +1418,7 @@ const onsuccess = () => {
       const isValidPropertiesObject = data.eventPropertiesObject && isValidObject(data.eventPropertiesObject);
       let eventProperties = propertiesBaisc;
       if (isValidPropertiesObject) {
+        // Clone
         const cleanedPropertiesObject = JSON.parse(JSON.stringify(data.eventPropertiesObject));
         // remove the user_properties
         Object.delete(cleanedPropertiesObject, 'user_properties');

--- a/template.tpl
+++ b/template.tpl
@@ -1240,22 +1240,23 @@ const WRAPPER_NAMESPACE = '_amplitude';
 
 // Print a log message and set the tag to failed state
 const fail = msg => {
-  log(LOG_PREFIX + 'Error: ' + msg);
   return data.gtmOnFailure();
 };
 
 // Merge two Objects
-const mergeObject = (obj1, obj2) => {
-  if (!obj1 || Object.keys(obj1).length == 0) return obj2;
-  if (!obj2 || Object.keys(obj2).length == 0) return obj1;
+const mergeObject = (basedObject, overwriteObject) => {
+  if (!basedObject || Object.keys(basedObject).length == 0) return overwriteObject;
+  if (!basedObject || Object.keys(overwriteObject).length == 0) return basedObject;
 
   // Clone
-  const newObject = JSON.parse(JSON.stringify(obj1));
+  const newObject = JSON.parse(JSON.stringify(basedObject));
 
-  if (newObject == undefined)
-    return obj2;
+  if (newObject == undefined) {
+    log(LOG_PREFIX + 'Error: Input has been dropped because it\'s an unexpected Object type.');
+    return overwriteObject;
+  }
 
-  Object.entries(obj2).forEach((entry) => {
+  Object.entries(overwriteObject).forEach((entry) => {
     const key = entry[0];
     const value = entry[1];
     newObject[key] = value;
@@ -1265,7 +1266,9 @@ const mergeObject = (obj1, obj2) => {
 };
 
 const isValidObject = (input) => {
-  return getType(input) == 'object';
+  const isObject = getType(input) == 'object';
+  log(LOG_PREFIX + 'Error: In valid object input.');
+  return isObject;
 };
 
 // Normalize options' values
@@ -1613,4 +1616,5 @@ setup: ''
 ___NOTES___
 
 Created on 27/10/2021, 18:34:01
+
 

--- a/template.tpl
+++ b/template.tpl
@@ -401,7 +401,7 @@ ___TEMPLATE_PARAMETERS___
         "type": "TEXT"
       },
       {
-        "displayName": "Event Properties Basic",
+        "displayName": "Individual Event Properties",
         "name": "eventPropertiesBasic",
         "simpleTableColumns": [
           {
@@ -428,7 +428,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid event properties object. This overwrites the event properties in \u003cstrong\u003eEvent Properties Basic\u003c/strong\u003e if there are any duplicate keys. Amplitude ignores any inputs not in the object format and any value under user_properties key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
+        "help": "Select a GTM variable that returns a valid event properties object. This overwrites the event properties in \u003cstrong\u003eIndividual Event Properties\u003c/strong\u003e if there are any duplicate keys. Amplitude ignores any inputs not in the object format and any value under user_properties key. \u003ca href\u003d\"www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\"\u003e Click here for an example\u003c/a\u003e.",
         "notSetText": "Don\u0027t set an Event Property Object"
       },
       {


### PR DESCRIPTION
Provide 2 ways for adding Event properties.
- The original event properties go to `Event Properties Basic`
- The new object type event properties go to `Event Properties Object`
    - here provide a dropdown to let customer choose their GTM variables. All variables are available, however, only the object format is allowed. 
    - this event properties value will overwrite the event properties basic if there has any duplicate.

![Screenshot 2024-04-19 at 6 08 47 PM](https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/13028329/59d12689-8d89-4fde-ac22-c8c51afc6dcc)

<img width="791" alt="Screenshot 2024-04-26 at 10 31 10 AM" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/13028329/0c7da48d-59cc-4669-867c-61ff76fe7269">

The related doc update:
https://github.com/amplitude/amplitude-dev-center/pull/261