### PR TITLE
Bump up the SDK wrapper to fix issue of the missing events while closing the page

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1221,7 +1221,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.7.7';
+const WRAPPER_VERSION = '3.7.8';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
Related to https://github.com/amplitude/amplitude-js-gtm/pull/43