### PR TITLE
feat: enable json object input for identify call

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -758,8 +758,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}. \u003ca href\u003d\"//www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object
-\"\u003eClick here for an example\u003c/a\u003e. This bulk operation only supports the \u0027set\u0027 operation. This bulk operation only supports the `set` operation. This will overwrite the <strong>Individual operation</strong> user properties if there has any duplicate key.",
+        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. Only the values nested under the `user_properties` key are considered for the user properties. This bulk operation only supports the `set` operation. This overwrites the \u003cstrong\u003eIndividual operation\u003c/strong\u003e user properties if there are any duplicate keys. \u003ca href\u003d\"//www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object\n\"\u003eClick here for an example\u003c/a\u003e.",
         "notSetText": "Don\u0027t set an User Properties Object"
       }
     ]

--- a/template.tpl
+++ b/template.tpl
@@ -758,7 +758,8 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}. \u003ca href\u003d\"\"\u003eClick here for an example\u003c/a\u003e. This bulk operation only supports the \u0027set\u0027 action. This will overwrite the previous user properties if there has any duplicate key.",
+        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}. \u003ca href\u003d\"//www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#event-properties-object
+\"\u003eClick here for an example\u003c/a\u003e. This bulk operation only supports the \u0027set\u0027 operation. This bulk operation only supports the `set` operation. This will overwrite the <strong>Individual operation</strong> user properties if there has any duplicate key.",
         "notSetText": "Don\u0027t set an User Properties Object"
       }
     ]

--- a/template.tpl
+++ b/template.tpl
@@ -758,7 +758,7 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}. \u003ca href\u003d\"\"\u003eClick here for an example\u003c/a\u003e. This bulk operation only supports the \u0027set\u0027 action. This will overwrite the previous event properties if there has any duplicate key.",
+        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}. \u003ca href\u003d\"\"\u003eClick here for an example\u003c/a\u003e. This bulk operation only supports the \u0027set\u0027 action. This will overwrite the previous user properties if there has any duplicate key.",
         "notSetText": "Don\u0027t set an User Properties Object"
       }
     ]

--- a/template.tpl
+++ b/template.tpl
@@ -1426,7 +1426,7 @@ const getAllUserProps = (data) => {
 
 const getUserPropsBulkSetObject = (data) => {
   const userPropsObject = data.userPropertyOperationsObject;
-  if (!userPropsObject) {
+  if (!userPropsObject || !isValidObject(userPropsObject)) {
     return [];
   }
 
@@ -1456,7 +1456,6 @@ const onsuccess = () => {
   const instanceName = data.instanceName;
 
   switch (data.type) {
-
     case 'init':
       _amplitude(instanceName, 'init', data.apiKey, initUserId, generateConfiguration());
       break;
@@ -1504,7 +1503,7 @@ const onsuccess = () => {
       break;
 
     case 'groupIdentify':
-      const mergedGroupUserProps = getAllUserProps(data.userPropertyOperations);
+      const mergedGroupUserProps = getAllUserProps(data);
       _amplitude(instanceName, 'groupIdentify', data.identifyGroupType, mergedGroupUserProps);
       break;
 

--- a/template.tpl
+++ b/template.tpl
@@ -758,7 +758,8 @@ ___TEMPLATE_PARAMETERS___
         "macrosInSelect": true,
         "selectItems": [],
         "simpleValueType": true,
-        "help": "Choose object format variable to set multiple user properties at once. This bulk operation only supports the \u0027set\u0027 action. This will overwrite the previous event properties if there has any duplicate key. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}."
+        "help": "Select a GTM variable that returns a valid User Properties object to set multiple user properties at once. The key and value pairs for user properties must be nested under the `user_properties` key. i.e. : {user_properties: {\u0027userIdentifyKey\u0027: \u0027userIdentifyValue\u0027}}. \u003ca href\u003d\"\"\u003eClick here for an example\u003c/a\u003e. This bulk operation only supports the \u0027set\u0027 action. This will overwrite the previous event properties if there has any duplicate key.",
+        "notSetText": "Don\u0027t set an User Properties Object"
       }
     ]
   },
@@ -1425,8 +1426,13 @@ const getAllUserProps = (data) => {
 
 const getUserPropsBulkSetObject = (data) => {
   const userPropsObject = data.userPropertyOperationsObject;
+  if (!userPropsObject) {
+    return [];
+  }
+
   if (Object.entries(userPropsObject).length != 0 && !userPropsObject.user_properties) {
     log(LOG_PREFIX + 'Error: The bulk set operation for user properties was ignored because the expected`user_properties` key is missing in the identify input.');
+    return [];
   }
 
   const userPropsBulk = [];


### PR DESCRIPTION
Enable the possibility to choose a GTM variable to set the identify calls.
1. all key, value pair will be identify set operation
2. the Varible must be nested under the user_properties key. i.e. {user_priorities: {key: value}}. Because the user properties of `Google Tag: Event Settings` type variable, which is provided by GTM,  is under `user_properties` key. 

<img width="806" alt="Screenshot 2024-04-23 at 5 19 41 PM" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/13028329/e70f8958-d3b7-4e51-b265-cd9aebdf2e5c">

<img width="710" alt="Screenshot 2024-04-26 at 10 40 47 AM" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/13028329/36dd1762-ff5f-40df-9b65-baf089d04e57">


<img width="1160" alt="Screenshot 2024-04-23 at 4 15 41 PM" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/13028329/54167646-ed06-4439-95e4-d4e837ca9de5">

Related doc update:
https://github.com/amplitude/amplitude-dev-center/pull/261
