### PR TITLE
fix the metadata update github action

### DIFF
--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -1,11 +1,7 @@
 name: Update Metadata
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - template.tpl  # The workflow should only trigger on changes to template.tpl
+  workflow_dispatch:
 
 jobs:
   update-metadata:

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update metadata.yaml
         run: |
           SHA=$(git rev-parse HEAD)
-          MESSAGE=$(git log -1 --pretty=%B)
+          MESSAGE=$(git log --skip=1 --max-count=1 --pretty=%B)
           NEW_VERSION="  - sha: $SHA\n    changeNotes: $MESSAGE"
           echo "New version info to be added: \n"
           echo "$NEW_VERSION"

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -22,7 +22,7 @@ jobs:
           NEW_VERSION="  - sha: $SHA\n    changeNotes: $MESSAGE"
           echo "New version info to be added: \n"
           echo "$NEW_VERSION"
-          sed -i "s/versions:/versions:\n$NEW_VERSION/" metadata.yaml       
+          sed -i "s|versions:|versions:\n$NEW_VERSION|" metadata.yaml       
 
       - name: Commit and push if changed
         run: |


### PR DESCRIPTION
`sed` command in github action uses `\` as the delimiter. However, while merging, it always merges from the sub-branch to the main branch, it always contains \  in the `$NEW_VERSION`, like `amplitude\subbranch`. This will cause a failure to update the metadata.yeal file.

<img width="938" alt="Screenshot 2024-04-24 at 11 23 42 AM" src="https://github.com/amplitude/amplitude-browser-sdk-gtm-template/assets/13028329/51e03dfb-d0fc-4f7b-b64f-8816393caff6">
