### PR TITLE
Bumpup SDK version to fix web attribuiton and session start event order and page counter bug

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,8 @@
 homepage: "https://www.amplitude.com/"
 documentation: "https://www.docs.developers.amplitude.com/data/sdks/marketing-analytics-browser/"
 versions:
+  - sha: 2c4d5030193d608c14759343736eaf6a51c6d074
+    changeNotes: Bump up the SDK wrapper to fix issue of session start sending wrong utm values and page counter bug
   - sha: 0e83df5bcc5a6172ad1828e3eca49f54cc95ff0c
     changeNotes: Fix failed to load Amplitude namespace issue
   - sha: 0146f9e79ded2f1cfe8c01c0b991a4443dd9ea1e

--- a/template.tpl
+++ b/template.tpl
@@ -1221,7 +1221,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.7.9';
+const WRAPPER_VERSION = '3.7.10';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
- test using the local app: 
    1. the order of web attribution fires right.
    2. The page counter is right.