### PR TITLE
fix the missing event properties issue

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -402,7 +402,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "displayName": "Individual Event Properties",
-        "name": "eventPropertiesBasic",
+        "name": "eventProperties",
         "simpleTableColumns": [
           {
             "defaultValue": "",
@@ -1461,7 +1461,7 @@ const onsuccess = () => {
       break;
 
     case 'track':
-      const propertiesBaisc = makeTableMap(data.eventPropertiesBasic || [], 'name', 'value');
+      const propertiesBaisc = makeTableMap(data.eventProperties || [], 'name', 'value');
       const isValidPropertiesObject = data.eventPropertiesObject && isValidObject(data.eventPropertiesObject);
       let eventProperties = propertiesBaisc;
       if (isValidPropertiesObject) {


### PR DESCRIPTION
JIRA issue: https://amplitude.atlassian.net/browse/AMP-99408

Changing the original name of a field causes the original field in the tag to be missing. 

Update the key word for event properties back. 