### PR TITLE
Bump analytics-browser to 2.8.0 with wrapper to 3.7.12

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1243,7 +1243,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.7.11';
+const WRAPPER_VERSION = '3.7.12';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
feat: support sessionId from url for cross domain tracking