### PR TITLE
fix: deviceId should not be number

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1305,6 +1305,13 @@ const normalize = val => {
   return makeNumber(val) || val;
 };
 
+// Normalize device Id
+const normalizeDeviceId = val => {
+  if (val === 'null') return null;
+  if (val === 'undefined') return undefined;
+  return val;
+};
+
 // Split a string into an array and trim the constituents of leading and trailing whitespace
 const stringToArrayAndTrim = str => str.split(',').map(n => makeString(n.trim()));
 
@@ -1528,6 +1535,10 @@ const onsuccess = () => {
       revenueObject.quantity = makeNumber(revenueObject.quantity);
       revenueObject.revenue = makeNumber(revenueObject.revenue);
       _amplitude(instanceName, 'revenue', revenueObject);
+      break;
+
+    case 'setDeviceId':
+      _amplitude(instanceName, 'setDeviceId', normalizeDeviceId(data.setDeviceId));
       break;
 
     default:


### PR DESCRIPTION
Jira ticket: [AMP-104568]

This PR skips the input value of `setDeviceId` tag for `normalize()` which converts string to number and will round/truncate float. 

[AMP-104568]: https://amplitude.atlassian.net/browse/AMP-104568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ