### PR TITLE
feat support excludeReferrers regex

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1761,11 +1761,11 @@ scenarios:
     assertApi('gtmOnSuccess').wasCalled();
 - name: Init tag with single exclude referrers regex
   code: |-
-    const excludeReferrersRegex = ["test.com", "text.org"];
+    const excludeReferrersRegex = "test.com";
     const expectedConfig = {
       defaultTracking: {
         attribution: {
-          excludeReferrersRegex: excludeReferrersRegex,
+          excludeReferrersRegex: [excludeReferrersRegex],
           resetSessionOnNewCampaign: undefined,
           initialEmptyValue: 'EMPTY',
         },

--- a/template.tpl
+++ b/template.tpl
@@ -1250,7 +1250,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.8.0';
+const WRAPPER_VERSION = '3.9.0';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -810,11 +810,24 @@ ___TEMPLATE_PARAMETERS___
                         "help": "By default, initial direct visits are tagged with the \"EMPTY\" campaign value. You can add a different initial empty value into this field. \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sdks/browser-2/#advanced-configuration-for-tracking-marketing-attribution\" \u003eRead more\u003c/a\u003e."
                       },
                       {
-                        "type": "TEXT",
-                        "name": "attributionExcludeReferrers",
-                        "displayName": "Exclude Referrers",
-                        "simpleValueType": true,
-                        "help": "Pass a comma-separated list of referring domains you want to exclude from campaign attribution. \u003ca href\u003d\"\"\u003eRead more\u003c/a\u003e."
+                        "type": "GROUP",
+                        "name": "attributionExcludeReferrersGroup",
+                        "displayName": "",
+                        "groupStyle": "NO_ZIPPY",
+                        "subParams": [
+                          {
+                            "type": "TEXT",
+                            "name": "attributionExcludeReferrersText",
+                            "displayName": "Exclude referrers text",
+                            "simpleValueType": true
+                          },
+                          {
+                            "type": "TEXT",
+                            "name": "attributionExcludeReferrersRegex",
+                            "displayName": "Exclude referrers regex",
+                            "simpleValueType": true
+                          }
+                        ]
                       },
                       {
                         "type": "CHECKBOX",
@@ -1357,11 +1370,15 @@ const generateConfiguration = () => {
 
     if (!!data.detAttribution) {
       initOptions.defaultTracking.attribution = {};
-
-      if (!!data.attributionExcludeReferrers) {
-        // TODO: How to deal with regular expression input
-        initOptions.defaultTracking.attribution.excludeReferrers = getType(data.attributionExcludeReferrers) === 'array' ? data.attributionExcludeReferrers : stringToArrayAndTrim(data.attributionExcludeReferrers);
+      
+      if (!!data.attributionExcludeReferrersText) {
+        initOptions.defaultTracking.attribution.excludeReferrersText = getType(data.attributionExcludeReferrersText) === 'array' ? data.attributionExcludeReferrersText : stringToArrayAndTrim(data.attributionExcludeReferrersText);
       }
+      
+      if (!!data.attributionExcludeReferrersRegex) {
+        initOptions.defaultTracking.attribution.excludeReferrersRegex = getType(data.attributionExcludeReferrersRegex) === 'array' ? data.attributionExcludeReferrersRegex : stringToArrayAndTrim(data.attributionExcludeReferrersRegex);
+      }
+
       initOptions.defaultTracking.attribution.resetSessionOnNewCampaign = data.attributionResetSession;
       initOptions.defaultTracking.attribution.initialEmptyValue = data.attributionInitialEmptyValue || 'EMPTY';
     } else {

--- a/template.tpl
+++ b/template.tpl
@@ -1750,7 +1750,7 @@ scenarios:
         assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
         assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
         assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
-         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+        assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
       };
     });
 
@@ -1789,7 +1789,7 @@ scenarios:
         assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
         assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
         assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
-         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+        assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
       };
     });
 
@@ -1828,7 +1828,7 @@ scenarios:
         assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
         assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
         assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
-         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+        assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
       };
     });
 
@@ -1870,7 +1870,7 @@ scenarios:
         assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
         assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
         assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
-         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+        assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
       };
     });
 

--- a/template.tpl
+++ b/template.tpl
@@ -1680,6 +1680,205 @@ ___WEB_PERMISSIONS___
 ___TESTS___
 
 scenarios:
+- name: Init tag with a single exclude referrer
+  code: |-
+    const excludeReferrers = "test.com";
+    const expectedConfig = {
+      defaultTracking: {
+        attribution: {
+          excludeReferrersText: [excludeReferrers],
+          resetSessionOnNewCampaign: undefined,
+          initialEmptyValue: 'EMPTY',
+        },
+        pageViews: false,
+        sessions: false,
+        fileDownloads: false,
+        formInteractions: false,
+      }
+    };
+
+    mockData.type = 'init';
+    mockData.defaultEventTracking = true;
+    mockData.detAttribution = true;
+    mockData.attributionExcludeReferrers = excludeReferrers;
+
+    // Test the following line:
+    // _amplitude(instanceName, 'init', data.apiKey, initUserId, generateConfiguration());
+    mock('copyFromWindow', key => {
+      return function() {
+        assertThat(arguments[0], 'Incorrect instance name').isEqualTo(mockData.instanceName);
+        assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
+        assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
+        assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
+        assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+
+      };
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Init tag with multiple exclude referrers
+  code: |-
+    const excludeReferrers = ["test.com", "text.org"];
+    const expectedConfig = {
+      defaultTracking: {
+        attribution: {
+          excludeReferrersText: excludeReferrers,
+          resetSessionOnNewCampaign: undefined,
+          initialEmptyValue: 'EMPTY',
+        },
+        pageViews: false,
+        sessions: false,
+        fileDownloads: false,
+        formInteractions: false,
+      }
+    };
+
+    mockData.type = 'init';
+    mockData.defaultEventTracking = true;
+    mockData.detAttribution = true;
+    mockData.attributionExcludeReferrers = excludeReferrers;
+
+    // Test the following line:
+    // _amplitude(instanceName, 'init', data.apiKey, initUserId, generateConfiguration());
+    mock('copyFromWindow', key => {
+      return function() {
+        assertThat(arguments[0], 'Incorrect instance name').isEqualTo(mockData.instanceName);
+        assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
+        assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
+        assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
+         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+      };
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Init tag with single exclude referrers regex
+  code: |-
+    const excludeReferrersRegex = ["test.com", "text.org"];
+    const expectedConfig = {
+      defaultTracking: {
+        attribution: {
+          excludeReferrersRegex: excludeReferrersRegex,
+          resetSessionOnNewCampaign: undefined,
+          initialEmptyValue: 'EMPTY',
+        },
+        pageViews: false,
+        sessions: false,
+        fileDownloads: false,
+        formInteractions: false,
+      }
+    };
+
+    mockData.type = 'init';
+    mockData.defaultEventTracking = true;
+    mockData.detAttribution = true;
+    mockData.attributionExcludeReferrersRegex = excludeReferrersRegex;
+
+    // Test the following line:
+    // _amplitude(instanceName, 'init', data.apiKey, initUserId, generateConfiguration());
+    mock('copyFromWindow', key => {
+      return function() {
+        assertThat(arguments[0], 'Incorrect instance name').isEqualTo(mockData.instanceName);
+        assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
+        assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
+        assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
+         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+      };
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Init tag with multiple exclude referrers regex
+  code: |-
+    const excludeReferrersRegex = ["test.com", "text.org"];
+    const expectedConfig = {
+      defaultTracking: {
+        attribution: {
+          excludeReferrersRegex: excludeReferrersRegex,
+          resetSessionOnNewCampaign: undefined,
+          initialEmptyValue: 'EMPTY',
+        },
+        pageViews: false,
+        sessions: false,
+        fileDownloads: false,
+        formInteractions: false,
+      }
+    };
+
+    mockData.type = 'init';
+    mockData.defaultEventTracking = true;
+    mockData.detAttribution = true;
+    mockData.attributionExcludeReferrersRegex = excludeReferrersRegex;
+
+    // Test the following line:
+    // _amplitude(instanceName, 'init', data.apiKey, initUserId, generateConfiguration());
+    mock('copyFromWindow', key => {
+      return function() {
+        assertThat(arguments[0], 'Incorrect instance name').isEqualTo(mockData.instanceName);
+        assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
+        assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
+        assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
+         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+      };
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
+- name: Init tag with both exclude referrers text and regex
+  code: |-
+    const excludeReferrers = ["a.com", "b.org"];
+    const excludeReferrersRegex = ["c.com", "d.org"];
+    const expectedConfig = {
+      defaultTracking: {
+        attribution: {
+          excludeReferrersText: excludeReferrers,
+          excludeReferrersRegex: excludeReferrersRegex,
+          resetSessionOnNewCampaign: undefined,
+          initialEmptyValue: 'EMPTY',
+        },
+        pageViews: false,
+        sessions: false,
+        fileDownloads: false,
+        formInteractions: false,
+      }
+    };
+
+    mockData.type = 'init';
+    mockData.defaultEventTracking = true;
+    mockData.detAttribution = true;
+    mockData.attributionExcludeReferrers = excludeReferrers;
+    mockData.attributionExcludeReferrersRegex = excludeReferrersRegex;
+
+    // Test the following line:
+    // _amplitude(instanceName, 'init', data.apiKey, initUserId, generateConfiguration());
+    mock('copyFromWindow', key => {
+      return function() {
+        assertThat(arguments[0], 'Incorrect instance name').isEqualTo(mockData.instanceName);
+        assertThat(arguments[1], 'Incorrect tag type').isEqualTo(mockData.type);
+        assertThat(arguments[2], 'Incorrect apiKey object').isEqualTo(mockData.apiKey);
+        assertThat(arguments[3], 'Incorrect user Id').isEqualTo(null);
+         assertThat(arguments[4], 'Incorrect config').isEqualTo(expectedConfig);
+      };
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that the tag finished successfully.
+    assertApi('gtmOnSuccess').wasCalled();
 - name: Track tag with individual event properties
   code: "\nmockData.type = 'track';\nmockData.eventType = 'test_event';\n\nconst eventProperties\
     \ = {\n  'individual_ep_key1': 'individual_ep_value1', \n  'individual_ep_key2':\
@@ -2088,21 +2287,21 @@ scenarios:
 
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
-setup: "const object = require('Object');\n\nconst mockData = {\n  instanceName: '$default_instance'\n\
-  };\n\n// Helper function\nconst convertObjectToArray = function (obj, nameKey, valueKey){\n\
-  \    var result = [];\n    for (var key in obj) {\n        if (obj.hasOwnProperty(key))\
-  \ {\n            var entry = {};\n            entry[nameKey] = key;\n          \
-  \  entry[valueKey] = obj[key];\n            result.push(entry);\n        }\n   \
-  \ }\n    return result;\n};\n\nconst mergeProperties = function(obj, result, ignoredKey)\
-  \ {\n  object.entries(obj).forEach((entry) => {\n    const key = entry[0];\n   \
-  \ if (key !== ignoredKey) {\n      const value = entry[1];\n      result[key] =\
-  \ value;    \n    }\n  });\n  return result;\n};\n\nconst mergeObject = function\
-  \ (baseObj, overwriteObj, ignoredKey){\n    const filteredBaseObj = mergeProperties(baseObj,\
-  \ {}, ignoredKey);    // Merge base object into new object\n    const filteredMergedObj\
-  \ = mergeProperties(overwriteObj, filteredBaseObj, ignoredKey);  // Overwrite with\
-  \ the second object\n    return filteredMergedObj;\n};\n\nlet success, failure;\n\
-  mock('injectScript', (url, onsuccess, onfailure) => {\n  success = onsuccess;\n\
-  \  failure = onfailure;\n  onsuccess();\n});\n     "
+setup: "const object = require('Object');\n\nconst mockData = {\n  instanceName: '$default_instance',\n\
+  \  apiKey: 'test_api_key',\n};\n\n// Helper function\nconst convertObjectToArray\
+  \ = function (obj, nameKey, valueKey){\n    var result = [];\n    for (var key in\
+  \ obj) {\n        if (obj.hasOwnProperty(key)) {\n            var entry = {};\n\
+  \            entry[nameKey] = key;\n            entry[valueKey] = obj[key];\n  \
+  \          result.push(entry);\n        }\n    }\n    return result;\n};\n\nconst\
+  \ mergeProperties = function(obj, result, ignoredKey) {\n  object.entries(obj).forEach((entry)\
+  \ => {\n    const key = entry[0];\n    if (key !== ignoredKey) {\n      const value\
+  \ = entry[1];\n      result[key] = value;    \n    }\n  });\n  return result;\n\
+  };\n\nconst mergeObject = function (baseObj, overwriteObj, ignoredKey){\n    const\
+  \ filteredBaseObj = mergeProperties(baseObj, {}, ignoredKey);    // Merge base object\
+  \ into new object\n    const filteredMergedObj = mergeProperties(overwriteObj, filteredBaseObj,\
+  \ ignoredKey);  // Overwrite with the second object\n    return filteredMergedObj;\n\
+  };\n\nlet success, failure;\nmock('injectScript', (url, onsuccess, onfailure) =>\
+  \ {\n  success = onsuccess;\n  failure = onfailure;\n  onsuccess();\n});\n     "
 
 
 ___NOTES___

--- a/template.tpl
+++ b/template.tpl
@@ -810,24 +810,18 @@ ___TEMPLATE_PARAMETERS___
                         "help": "By default, initial direct visits are tagged with the \"EMPTY\" campaign value. You can add a different initial empty value into this field. \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sdks/browser-2/#advanced-configuration-for-tracking-marketing-attribution\" \u003eRead more\u003c/a\u003e."
                       },
                       {
-                        "type": "GROUP",
-                        "name": "attributionExcludeReferrersGroup",
-                        "displayName": "",
-                        "groupStyle": "NO_ZIPPY",
-                        "subParams": [
-                          {
-                            "type": "TEXT",
-                            "name": "attributionExcludeReferrersText",
-                            "displayName": "Exclude referrers text",
-                            "simpleValueType": true
-                          },
-                          {
-                            "type": "TEXT",
-                            "name": "attributionExcludeReferrersRegex",
-                            "displayName": "Exclude referrers regex",
-                            "simpleValueType": true
-                          }
-                        ]
+                        "type": "TEXT",
+                        "name": "attributionExcludeReferrers",
+                        "displayName": "Exclude Referrers String",
+                        "simpleValueType": true,
+                        "help": "Pass a comma-separated list of referring domains you want to exclude from campaign attribution. Each one of them performs exact match. For regex, use \"Exclude Referrers Regex\" instead\u003ca href\u003d\"https://amplitude.com/docs/data/source-catalog/google-tag-manager#init\"\u003eRead more\u003c/a\u003e."
+                      },
+                      {
+                        "type": "TEXT",
+                        "name": "attributionExcludeReferrersRegex",
+                        "displayName": "Exclude Referrers Regex",
+                        "simpleValueType": true,
+                        "help": "Pass a comma-separated list of referring domains you want to exclude from campaign attribution. Each one of them is converted to a Regex object and performs regex match\u003ca href\u003d\"https://amplitude.com/docs/data/source-catalog/google-tag-manager#init\"\u003eRead more\u003c/a\u003e."
                       },
                       {
                         "type": "CHECKBOX",
@@ -1371,8 +1365,8 @@ const generateConfiguration = () => {
     if (!!data.detAttribution) {
       initOptions.defaultTracking.attribution = {};
       
-      if (!!data.attributionExcludeReferrersText) {
-        initOptions.defaultTracking.attribution.excludeReferrersText = getType(data.attributionExcludeReferrersText) === 'array' ? data.attributionExcludeReferrersText : stringToArrayAndTrim(data.attributionExcludeReferrersText);
+      if (!!data.attributionExcludeReferrers) {
+        initOptions.defaultTracking.attribution.excludeReferrersText = getType(data.attributionExcludeReferrers) === 'array' ? data.attributionExcludeReferrers : stringToArrayAndTrim(data.attributionExcludeReferrers);
       }
       
       if (!!data.attributionExcludeReferrersRegex) {


### PR DESCRIPTION
## UI
  - Keep the name of the existing textfield as `attributionExcludeReferrers` for backward compatibility
  - Add a textfield with name `attributionExcludeReferrersRegex` to support regex exclude referrers. 
#### Before
<img width="451" alt="image" src="https://github.com/user-attachments/assets/de1b7d6b-9e53-47ef-a6ba-8aef2a43aa86">

#### After
<img width="506" alt="image" src="https://github.com/user-attachments/assets/6fa84f2e-b174-4998-acff-f8be69d763c8">


## Code 
Update sdk wrapper version to 3.9.0 https://github.com/amplitude/amplitude-js-gtm/pull/51

#### `generateConfiguration()` 
  - Assign `data.attributionExcludeReferrers` to `initOptions.defaultTracking.attribution.excludeReferrersText`
  - Assign `data.attributionExcludeReferrersRegex` to `initOptions.defaultTracking.attribution.excludeReferrersRegex`
  - The two exclude referrers in `initOptions` will be merged in https://github.com/amplitude/amplitude-js-gtm/pull/51

#### Test
- Add tests for init tag when exclude referrers text fields are set