### PR TITLE
fix: resolve crash caused by invalid regular expression

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1316,7 +1316,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.11.0';
+const WRAPPER_VERSION = '3.11.1';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
Bump up the wrapper version to fetch [this](https://github.com/amplitude/amplitude-js-gtm/pull/58) update