### PR TITLE
chore: add note for group properties

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -141,7 +141,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "LABEL",
     "name": "groupIdentifyDescription",
-    "displayName": "\u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sources/google-tag-manager-client/#groupidentify\"\u003eSet Group Properties\u003c/a\u003e - See also \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sdks/browser-2/#group-properties\"\u003eSDK Reference\u003c/a\u003e",
+    "displayName": "\u003ca href\u003d\"https://amplitude.com/docs/data/source-catalog/google-tag-manager#set-group-properties\"\u003eSet Group Properties\u003c/a\u003e - See also \u003ca href\u003d\"https://www.docs.developers.amplitude.com/data/sdks/browser-2/#group-properties\"\u003eSDK Reference\u003c/a\u003e. \u003cstrong\u003eNote that group properties are indeed user properties for each member in that group. So we will use the term \"user property\" instead of \"group property\" in the \"Identify Settings\" section\u003c/strong\u003e",
     "enablingConditions": [
       {
         "paramName": "type",


### PR DESCRIPTION
Jira: [AMP-115299]

"Identify Settings" section is shared by both "identify" and "group identify". However, it sticks with the word "user property" which causes confusion when comes to "group identify" with the expectation to be "group property". Previous version has already been released and the template only pulls `object.user_properties`. For backward compatibility, instead of pulling `object.group_properties`, we keep the template code and add a note there as group properties are just user properties for the group members. 

[AMP-115299]: https://amplitude.atlassian.net/browse/AMP-115299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ