### PR TITLE
fix: support identify.unset & bump to 2.11.10

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -725,6 +725,10 @@ ___TEMPLATE_PARAMETERS___
               {
                 "displayValue": "Clear All",
                 "value": "clearAll"
+              },
+              {
+                "value": "unset",
+                "displayValue": "Unset"
               }
             ],
             "defaultValue": "set",
@@ -1316,7 +1320,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.11.2';
+const WRAPPER_VERSION = '3.11.3';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
[AMP-119988](https://amplitude.atlassian.net/browse/AMP-119988)


Have an identify tag to unset:
<img width="998" alt="image" src="https://github.com/user-attachments/assets/201fae42-f911-43fb-8472-e9b65ec381d8" />

Successfully unset
<img width="770" alt="image" src="https://github.com/user-attachments/assets/5692b19a-4d4b-4dbe-9c7a-a8b21675feae" />


[AMP-119988]: https://amplitude.atlassian.net/browse/AMP-119988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ