### PR TITLE
chore: bump WRAPPER_VERSION to 3.17.2

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1353,7 +1353,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.17.0';
+const WRAPPER_VERSION = '3.17.1';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -1353,7 +1353,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '3.17.1';
+const WRAPPER_VERSION = '3.17.2';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
3.17.1 is the same as 3.17.2. Skipping it and bump to 3.17.2