### PR TITLE
fix: set proper rageClick and deadClick css selectors

### DIFF
--- a/libs/sandboxed-js.js
+++ b/libs/sandboxed-js.js
@@ -224,26 +224,28 @@ const generateConfiguration = (data) => {
       }
     }
 
-    const frustrationInteractionsOptions = data.frustrationInteractionsOptions || {};
-
-    if (!!frustrationInteractionsOptions.rageClicksCssSelectorAllowlist) {
-      const rageClicks = {};
-      frustrationInteractionsOptions.rageClicks = rageClicks;
-      rageClicks.cssSelectorAllowlist = getType(frustrationInteractionsOptions.rageClicksCssSelectorAllowlist) === 'array' ? data.rageClicksCssSelectorAllowlist : stringToArrayAndTrim(frustrationInteractionsOptions.rageClicksCssSelectorAllowlist);
-    }
-  
-    if (!!frustrationInteractionsOptions.deadClicksCssSelectorAllowlist) {
-      const deadClicks = {};
-      frustrationInteractionsOptions.deadClicks = deadClicks;
-      deadClicks.cssSelectorAllowlist = getType(frustrationInteractionsOptions.deadClicksCssSelectorAllowlist) === 'array' ? data.deadClicksCssSelectorAllowlist : stringToArrayAndTrim(frustrationInteractionsOptions.deadClicksCssSelectorAllowlist);
-    }
-    
-    const hasFrustrationInteractionsOptions = Object.keys(frustrationInteractionsOptions).length > 0;
     if (!!data.autocaptureFrustrationInteractions) {
+      let rageClicks;
+      let deadClicks;
+      
+      if (!!data.rageClicksCssSelectorAllowlist) {
+        rageClicks = {};
+        rageClicks.cssSelectorAllowlist = getType(data.rageClicksCssSelectorAllowlist) === 'array' ? data.rageClicksCssSelectorAllowlist : stringToArrayAndTrim(data.rageClicksCssSelectorAllowlist);
+      }
+    
+      if (!!data.deadClicksCssSelectorAllowlist) {
+        deadClicks = {};
+        deadClicks.cssSelectorAllowlist = getType(data.deadClicksCssSelectorAllowlist) === 'array' ? data.deadClicksCssSelectorAllowlist : stringToArrayAndTrim(data.deadClicksCssSelectorAllowlist);
+      }
+    
+      const hasFrustrationInteractionsOptions = !!rageClicks || !!deadClicks;
       if (!hasFrustrationInteractionsOptions) {
         initOptions.autocapture.frustrationInteractions = true; 
       } else {
-        initOptions.autocapture.frustrationInteractions = frustrationInteractionsOptions;
+        initOptions.autocapture.frustrationInteractions = {
+          rageClicks: rageClicks,
+          deadClicks: deadClicks,
+        };
       }
     }
 

--- a/src/mock-data/kitchen-sink.ts
+++ b/src/mock-data/kitchen-sink.ts
@@ -18,8 +18,8 @@ const data: GtmParameters = {
   detSession: true,
   autocaptureFrustrationInteractions: true,
   frustrationInteractionsOptions: {
-    rageClicksCssSelectorAllowlist: '*',
-    deadClicksCssSelectorAllowlist: '*',
+    rageClicksCssSelectorAllowlist: '*,*,*',
+    deadClicksCssSelectorAllowlist: '*,*,*',
   },
   gtmOnSuccess: function () {
     console.log('gtmOnSuccess');

--- a/template.tpl
+++ b/template.tpl
@@ -1674,26 +1674,28 @@ const generateConfiguration = (data) => {
       }
     }
 
-    const frustrationInteractionsOptions = data.frustrationInteractionsOptions || {};
-
-    if (!!frustrationInteractionsOptions.rageClicksCssSelectorAllowlist) {
-      const rageClicks = {};
-      frustrationInteractionsOptions.rageClicks = rageClicks;
-      rageClicks.cssSelectorAllowlist = getType(frustrationInteractionsOptions.rageClicksCssSelectorAllowlist) === 'array' ? data.rageClicksCssSelectorAllowlist : stringToArrayAndTrim(frustrationInteractionsOptions.rageClicksCssSelectorAllowlist);
-    }
-  
-    if (!!frustrationInteractionsOptions.deadClicksCssSelectorAllowlist) {
-      const deadClicks = {};
-      frustrationInteractionsOptions.deadClicks = deadClicks;
-      deadClicks.cssSelectorAllowlist = getType(frustrationInteractionsOptions.deadClicksCssSelectorAllowlist) === 'array' ? data.deadClicksCssSelectorAllowlist : stringToArrayAndTrim(frustrationInteractionsOptions.deadClicksCssSelectorAllowlist);
-    }
-    
-    const hasFrustrationInteractionsOptions = Object.keys(frustrationInteractionsOptions).length > 0;
     if (!!data.autocaptureFrustrationInteractions) {
+      let rageClicks;
+      let deadClicks;
+      
+      if (!!data.rageClicksCssSelectorAllowlist) {
+        rageClicks = {};
+        rageClicks.cssSelectorAllowlist = getType(data.rageClicksCssSelectorAllowlist) === 'array' ? data.rageClicksCssSelectorAllowlist : stringToArrayAndTrim(data.rageClicksCssSelectorAllowlist);
+      }
+    
+      if (!!data.deadClicksCssSelectorAllowlist) {
+        deadClicks = {};
+        deadClicks.cssSelectorAllowlist = getType(data.deadClicksCssSelectorAllowlist) === 'array' ? data.deadClicksCssSelectorAllowlist : stringToArrayAndTrim(data.deadClicksCssSelectorAllowlist);
+      }
+    
+      const hasFrustrationInteractionsOptions = !!rageClicks || !!deadClicks;
       if (!hasFrustrationInteractionsOptions) {
         initOptions.autocapture.frustrationInteractions = true; 
       } else {
-        initOptions.autocapture.frustrationInteractions = frustrationInteractionsOptions;
+        initOptions.autocapture.frustrationInteractions = {
+          rageClicks: rageClicks,
+          deadClicks: deadClicks,
+        };
       }
     }
 

--- a/tests/generate-configuration.spec.ts
+++ b/tests/generate-configuration.spec.ts
@@ -71,10 +71,8 @@ describe('generateConfiguration', () => {
       const data: GeneratedGtmParameters = {
         ...BASE_DATA,
         autocaptureFrustrationInteractions: true,
-        frustrationInteractionsOptions: {
-          rageClicksCssSelectorAllowlist: 'test1,test2',
-          deadClicksCssSelectorAllowlist: 'test1,test2',
-        },
+        rageClicksCssSelectorAllowlist: 'test1,test2',
+        deadClicksCssSelectorAllowlist: 'test1,test2',
       }
       const autocapture = win.__EXPORTS__.generateConfiguration(data).autocapture;
       expect(autocapture.frustrationInteractions.rageClicks.cssSelectorAllowlist).toEqual(['test1', 'test2']);


### PR DESCRIPTION
### Summary

The CSS selector allowlists for rageClick and deadClick aren't being picked up because they're pointing to the wrong object. 

This was uncaught in the manual test we did, because the client was using a remote configuration that had the properties set, so it went undetected.

<img width="1468" height="923" alt="Screenshot 2025-10-07 at 1 10 24 PM" src="https://github.com/user-attachments/assets/0bb768f6-5a9d-4fe6-99a5-60d60973c503" />

<img width="1444" height="904" alt="Screenshot 2025-10-07 at 1 10 50 PM" src="https://github.com/user-attachments/assets/4c552742-0c18-4f6e-a841-2e92b7af69ff" />


### Checklist

* [x] If this pull request makes changes to "template.tpl", did you test this in tagmanager.google.com in Preview mode?
* [x] Did you make sure that the most recent version of "template.tpl" was tested? (in case one of your commits overwrote the template.tpl that you had previously tested)
* [x] Did you provide screenshots or recording verifying your changes?
