### PR TITLE
upgrade analytics to 2.39.0

### DIFF
--- a/libs/sandboxed-js.js
+++ b/libs/sandboxed-js.js
@@ -10,7 +10,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.36.9';
+const WRAPPER_VERSION = '2.39.0';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';
@@ -134,6 +134,9 @@ const generateConfiguration = (data) => {
       deviceModel: data.deviceModel,
     };
   }
+
+  // disable custom enrichment until we add a field for it in the UI
+  initOptions.customEnrichment = false;
 
   // Configuration for Session Replay Plugin
   if (!!data.sessionReplay) {

--- a/template.tpl
+++ b/template.tpl
@@ -1543,7 +1543,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.36.9';
+const WRAPPER_VERSION = '2.39.0';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';
@@ -1667,6 +1667,9 @@ const generateConfiguration = (data) => {
       deviceModel: data.deviceModel,
     };
   }
+
+  // disable custom enrichment until we add a field for it in the UI
+  initOptions.customEnrichment = false;
 
   // Configuration for Session Replay Plugin
   if (!!data.sessionReplay) {

--- a/tests/__snapshots__/generate-configuration.spec.ts.snap
+++ b/tests/__snapshots__/generate-configuration.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`generateConfiguration attribution tracking disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -26,6 +27,7 @@ exports[`generateConfiguration attribution with custom initial empty value 1`] =
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -40,6 +42,7 @@ exports[`generateConfiguration basic autocapture options 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -65,6 +68,7 @@ exports[`generateConfiguration comma-separated strings for attribution exclude r
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -105,6 +109,7 @@ exports[`generateConfiguration comma-separated strings for element interactions 
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -119,6 +124,7 @@ exports[`generateConfiguration configuration with logLevel 4 to trigger info log
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "logLevel": 4,
   "sessionReplay": false,
@@ -128,6 +134,7 @@ exports[`generateConfiguration configuration with logLevel 4 to trigger info log
 exports[`generateConfiguration default event tracking disabled 1`] = `
 {
   "autocapture": false,
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -143,6 +150,7 @@ exports[`generateConfiguration deviceId, userId, partnerId, and appVersion shoul
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "deviceId": "6108573831392975095",
   "guidesSurveys": false,
   "partnerId": "6108573831392975095",
@@ -160,6 +168,7 @@ exports[`generateConfiguration element interactions disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -174,6 +183,7 @@ exports[`generateConfiguration empty and undefined optional fields 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -188,6 +198,7 @@ exports[`generateConfiguration eu data disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -208,6 +219,7 @@ exports[`generateConfiguration exclude internal referrers exclude internal refer
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -228,6 +240,7 @@ exports[`generateConfiguration exclude internal referrers exclude internal refer
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -302,6 +315,7 @@ exports[`generateConfiguration kitchen sink example 1`] = `
   "cookieOptions": {
     "domain": "test",
   },
+  "customEnrichment": false,
   "guidesSurveys": true,
   "pageViewLegacy": true,
   "serverZone": "EU",
@@ -327,6 +341,7 @@ exports[`generateConfiguration manual configuration options 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "serverUrl": "https://api2.amplitude.com",
   "sessionReplay": false,
@@ -342,6 +357,7 @@ exports[`generateConfiguration network tracking disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -421,6 +437,7 @@ exports[`generateConfiguration network tracking with complex capture rules 1`] =
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -443,6 +460,7 @@ exports[`generateConfiguration network tracking with string ignore amplitude req
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -462,6 +480,7 @@ exports[`generateConfiguration network tracking with string networkTrackingIgnor
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -479,6 +498,7 @@ exports[`generateConfiguration page history tracking all changes 1`] = `
     },
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -494,6 +514,7 @@ exports[`generateConfiguration page url enrichment is disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -508,6 +529,7 @@ exports[`generateConfiguration page url enrichment is enabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -522,6 +544,7 @@ exports[`generateConfiguration page view tracking disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -539,6 +562,7 @@ exports[`generateConfiguration page view with legacy option disabled 1`] = `
     },
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -553,6 +577,7 @@ exports[`generateConfiguration partial user agent enrichment options 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
   "userAgentEnrichmentOptions": {
@@ -573,6 +598,7 @@ exports[`generateConfiguration session replay and guides surveys explicitly disa
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -587,6 +613,7 @@ exports[`generateConfiguration session, file download, and form interaction disa
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }
@@ -601,6 +628,7 @@ exports[`generateConfiguration user agent enrichment disabled 1`] = `
     "pageViews": false,
     "sessions": false,
   },
+  "customEnrichment": false,
   "guidesSurveys": false,
   "sessionReplay": false,
 }

--- a/tests/__snapshots__/on-success.spec.ts.snap
+++ b/tests/__snapshots__/on-success.spec.ts.snap
@@ -66,6 +66,7 @@ exports[`onsuccess init operation with basic configuration 1`] = `
       null,
       {
         "autocapture": false,
+        "customEnrichment": false,
         "guidesSurveys": false,
         "sessionReplay": false,
       },


### PR DESCRIPTION
### Summary

* Upgrade analytics to v2.39.0
* Disables customEnrichment temporarily

### Checklist

* [x] If this pull request makes changes to "template.tpl", did you test this in tagmanager.google.com in Preview mode?
* [x] Did you make sure that the most recent version of "template.tpl" was tested? (in case one of your commits overwrote the template.tpl that you had previously tested)
* [x] Did you provide screenshots or recording verifying your changes?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the injected Amplitude GTM wrapper version and forces `customEnrichment` off during init, which can change data enrichment behavior at runtime. Risk is moderate because it affects initialization options used across all tag installs.
> 
> **Overview**
> Upgrades the injected Amplitude GTM wrapper from `2.36.9` to `2.39.0` (updating the CDN URL) in both `libs/sandboxed-js.js` and `template.tpl`.
> 
> Also explicitly sets `initOptions.customEnrichment = false` during initialization to disable custom enrichment until a UI field is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db649985edb7a38ac6fa21ca142a0486001b9831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->