### PR TITLE
chore: upgrade analytics-browser to 2.39.1

### DIFF
--- a/libs/sandboxed-js.js
+++ b/libs/sandboxed-js.js
@@ -10,7 +10,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.39.0';
+const WRAPPER_VERSION = '2.39.1';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -1407,7 +1407,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.39.0';
+const WRAPPER_VERSION = '2.39.1';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
### Summary

<!-- What does the PR do? -->

### Checklist

* [ ] If this pull request makes changes to "template.tpl", did you test this in tagmanager.google.com in Preview mode?
* [ ] Did you make sure that the most recent version of "template.tpl" was tested? (in case one of your commits overwrote the template.tpl that you had previously tested)
* [ ] Did you provide screenshots or recording verifying your changes?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump that only changes the loaded Amplitude wrapper asset URL; main risk is any behavior change in the upstream `analytics-browser-gtm-wrapper` release.
> 
> **Overview**
> Updates the Amplitude GTM template to load `analytics-browser-gtm-wrapper` **v2.39.1** by bumping `WRAPPER_VERSION` (in both `libs/sandboxed-js.js` and the embedded JS in `template.tpl`), which changes the CDN URL for the injected wrapper script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a56dc1dd0ba2955b217be8e7be6cca4377272b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->