### PR TITLE
upgrade analytics to 2.39.2

### DIFF
--- a/libs/sandboxed-js.js
+++ b/libs/sandboxed-js.js
@@ -10,7 +10,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.39.1';
+const WRAPPER_VERSION = '2.39.2';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -1407,7 +1407,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.39.1';
+const WRAPPER_VERSION = '2.39.2';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
### Summary

<!-- What does the PR do? -->

### Checklist

* [x] If this pull request makes changes to "template.tpl", did you test this in tagmanager.google.com in Preview mode?
* [x] Did you make sure that the most recent version of "template.tpl" was tested? (in case one of your commits overwrote the template.tpl that you had previously tested)
* [x] Did you provide screenshots or recording verifying your changes?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the pinned Amplitude GTM wrapper version, changing the CDN URL of the injected script; functional behavior is otherwise unchanged but runtime behavior depends on the new upstream wrapper build.
> 
> **Overview**
> Updates the Amplitude GTM template to load wrapper version `2.39.2` (from `2.39.1`) by bumping `WRAPPER_VERSION` in both `libs/sandboxed-js.js` and `template.tpl`, which changes the injected CDN script URL accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05955fa3259d8fc37886e43403a7bfdf53c47ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->