### PR TITLE
chore: upgrade analytics-browser to 2.42.1

### DIFF
--- a/libs/sandboxed-js.js
+++ b/libs/sandboxed-js.js
@@ -10,7 +10,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.39.2';
+const WRAPPER_VERSION = '2.42.1';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -1416,7 +1416,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.39.2';
+const WRAPPER_VERSION = '2.42.1';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
## Summary
- Bumps the bundled GTM wrapper from `2.39.2` → `2.42.1` (amplitude-ts/2.42.1).
- Single-line change in `libs/sandboxed-js.js`; `template.tpl` is the regenerated mirror via `pnpm build`.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` — 100/100 passed, 59 snapshots passed
- [ ] CI green
- [ ] Confirm `https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-2.42.1.min.js.br` is published before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)