### PR TITLE
chore: upgrade analytics-browser to 2.42.2

### DIFF
--- a/libs/sandboxed-js.js
+++ b/libs/sandboxed-js.js
@@ -10,7 +10,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.42.1';
+const WRAPPER_VERSION = '2.42.2';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';

--- a/template.tpl
+++ b/template.tpl
@@ -1416,7 +1416,7 @@ const makeTableMap = require('makeTableMap');
 const JSON = require('JSON');
 
 // Constants
-const WRAPPER_VERSION = '2.42.1';
+const WRAPPER_VERSION = '2.42.2';
 const JS_URL = 'https://cdn.amplitude.com/libs/analytics-browser-gtm-wrapper-'+WRAPPER_VERSION+'.min.js.br';
 const LOG_PREFIX = '[Amplitude / GTM] ';
 const WRAPPER_NAMESPACE = '_amplitude';


### PR DESCRIPTION
## Summary
- Update wrapper version from 2.42.1 to 2.42.2 in both `libs/sandboxed-js.js` and `template.tpl`

## Slack Thread
https://amplitude.slack.com/archives/D0AAV7P5PU2/p1778519240411189?thread_ts=1778519200.108889&cid=D0AAV7P5PU2

https://claude.ai/code/session_01BCkQBB12KtbBneynFTzW4W

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCkQBB12KtbBneynFTzW4W)_